### PR TITLE
Fix ArcGIS API loading - use https and stable version 4.29

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,12 +15,12 @@
 <link rel="shortcut icon" type="image/ico" href="//www.esri.com/favicon.ico" />
 <!-- End Favorite Bookmark Icon -->
 <link href="/tiles/static/esri-info.css" rel="stylesheet" type="text/css">
-<link href="//js.arcgis.com/next/esri/css/main.css" rel="stylesheet" type="text/css" />
+<link href="https://js.arcgis.com/4.29/esri/themes/light/main.css" rel="stylesheet" type="text/css" />
 <!-- Calcite Design System -->
 <link rel="stylesheet" href="https://js.arcgis.com/calcite-components/2.13.2/calcite.css" />
 <script type="module" src="https://js.arcgis.com/calcite-components/2.13.2/calcite.esm.js"></script>
 <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;600&family=Crimson+Text:ital@0;1&display=swap" rel="stylesheet">
-<script type="text/javascript" src="//js.arcgis.com/next/"></script>
+<script type="text/javascript" src="https://js.arcgis.com/4.29/"></script>
 
 <style>
     html, body {


### PR DESCRIPTION
Changed from protocol-relative URLs (//js.arcgis.com/next/) to explicit https URLs with stable version 4.29. This fixes "Can't find variable: require" error that occurred when the AMD loader failed to load.